### PR TITLE
Fix where Chrome Other bookmarks is not id 2

### DIFF
--- a/bookmark/BuiltinBookmark.js
+++ b/bookmark/BuiltinBookmark.js
@@ -89,13 +89,9 @@ export class BuiltinBookmark
 
   async #getChromeOtherBookmarksNodeId()
   {
-    const tree = await browser.bookmarks.getTree();
-    const otherBookmarks = tree[0].children.find(i => i.title === 'Other bookmarks')
+    const bookmarks = await browser.bookmarks.getTree();
+    const otherBookmarks = bookmarks[0].children.find(i => i.folderType === 'other')
 
-    if (otherBookmarks) {
-      return otherBookmarks.id
-    } else {
-      throw new Error('Could not find "Other bookmarks" id')
-    }
+    return otherBookmarks.id
   }
 }

--- a/bookmark/BuiltinBookmark.js
+++ b/bookmark/BuiltinBookmark.js
@@ -17,8 +17,11 @@ export class BuiltinBookmark
     this.#createMappingFor(
       await this.#getBookmarkNameFrom(this.#getNodeIdForBookmarksBar()),
       "${BOOKMARKS_BAR}");
+
+    const nodeId = await this.#getNodeIdForBookmarksMenu()
+
     this.#createMappingFor(
-      await this.#getBookmarkNameFrom(this.#getNodeIdForBookmarksMenu()),
+      await this.#getBookmarkNameFrom(nodeId),
       "${BOOKMARKS_MENU}");
   }
 
@@ -68,7 +71,7 @@ export class BuiltinBookmark
     }
   }
 
-  #getNodeIdForBookmarksMenu()
+  async #getNodeIdForBookmarksMenu()
   {
     if (BROWSER_VENDOR == BROWSER_FIREFOX)
     {
@@ -76,11 +79,23 @@ export class BuiltinBookmark
     }
     else if (BROWSER_VENDOR == BROWSER_CHROME)
     {
-      return "2";
+      return this.#getChromeOtherBookmarksNodeId()
     }
     else
     {
       throw `Unsupported browser vendor: ${BROWSER_VENDOR}`;
+    }
+  }
+
+  async #getChromeOtherBookmarksNodeId()
+  {
+    const tree = await browser.bookmarks.getTree();
+    const otherBookmarks = tree[0].children.find(i => i.title === 'Other bookmarks')
+
+    if (otherBookmarks) {
+      return otherBookmarks.id
+    } else {
+      throw new Error('Could not find "Other bookmarks" id')
     }
   }
 }

--- a/bookmark/BuiltinBookmark.js
+++ b/bookmark/BuiltinBookmark.js
@@ -14,15 +14,17 @@ export class BuiltinBookmark
 
   async init()
   {
-    this.#createMappingFor(
-      await this.#getBookmarkNameFrom(this.#getNodeIdForBookmarksBar()),
-      "${BOOKMARKS_BAR}");
-
-    const nodeId = await this.#getNodeIdForBookmarksMenu()
+    const bookmarksBarNodeId = await this.#getNodeIdForBookmarksBar()
 
     this.#createMappingFor(
-      await this.#getBookmarkNameFrom(nodeId),
-      "${BOOKMARKS_MENU}");
+        await this.#getBookmarkNameFrom(bookmarksBarNodeId),
+        "${BOOKMARKS_BAR}");
+
+    const bookmarksMenuNodeId = await this.#getNodeIdForBookmarksMenu()
+
+    this.#createMappingFor(
+        await this.#getBookmarkNameFrom(bookmarksMenuNodeId),
+        "${BOOKMARKS_MENU}");
   }
 
   substitute(name)
@@ -55,7 +57,7 @@ export class BuiltinBookmark
     }
   }
 
-  #getNodeIdForBookmarksBar()
+  async #getNodeIdForBookmarksBar()
   {
     if (BROWSER_VENDOR == BROWSER_FIREFOX)
     {
@@ -63,7 +65,7 @@ export class BuiltinBookmark
     }
     else if (BROWSER_VENDOR == BROWSER_CHROME)
     {
-      return "1";
+      return this.#getChromeSpecialFolderId('bookmarks-bar')
     }
     else
     {
@@ -79,7 +81,7 @@ export class BuiltinBookmark
     }
     else if (BROWSER_VENDOR == BROWSER_CHROME)
     {
-      return this.#getChromeOtherBookmarksNodeId()
+      return this.#getChromeSpecialFolderId('other')
     }
     else
     {
@@ -87,10 +89,15 @@ export class BuiltinBookmark
     }
   }
 
-  async #getChromeOtherBookmarksNodeId()
+  /**
+   * Returns node id for special folders in Chrome.
+   * @param {('bookmarks-bar'|'managed'|'mobile'|'other')} folderType
+   * @returns {Promise<*>}
+   */
+  async #getChromeSpecialFolderId(folderType)
   {
     const bookmarks = await browser.bookmarks.getTree();
-    const otherBookmarks = bookmarks[0].children.find(i => i.folderType === 'other')
+    const otherBookmarks = bookmarks[0].children.find(i => i.folderType === folderType)
 
     return otherBookmarks.id
   }


### PR DESCRIPTION
Some old references state that the "Other bookmarks" is always id 2 but it can be unique.

This pull request changes it so that it finds the "Other bookmarks", and returns the "id" that it finds.

I have no idea how to reproduce this issue accurately to help you verify.

The picture below shows the "Other bookmarks" with a different id.  This is a Chrome profile that is a few years on Windows 10.

![image](https://github.com/user-attachments/assets/b42ade17-36fa-4d7a-925f-97a65e124804)
