### PR TITLE
Change arg --parents to -p for MacOS

### DIFF
--- a/tools/install_third_party
+++ b/tools/install_third_party
@@ -53,7 +53,7 @@ __install_bootstrap()
 
 main()
 {
-  mkdir --parents ${third_party} \
+  mkdir -p ${third_party} \
     && __install_polyfill \
     && __install_filesaver \
     && __install_bootstrap \

--- a/tools/package
+++ b/tools/package
@@ -24,7 +24,7 @@ create_package_for()
 {
   browser_vendor="${1}"
   create_manifest_for "${browser_vendor}"
-  mkdir --parents "out/"
+  mkdir -p "out/"
   zip \
     --recurse-paths \
     --filesync \


### PR DESCRIPTION
On Unix systems like MacOS I guess `--parents` is not a valid argument for `mkdir`.
This PR updates `--parents` to `-p` which does work.

On the OpenBSD [man page](https://man.openbsd.org/mkdir) for `mkdir` it doesn't mention `parents`.

Here is [another repo](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6684) that encountered the same problem and made the [same change](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6689/files).